### PR TITLE
Specify pip3 install during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ git clone https://github.com/TapanSoni/BPStegano
 
 cd BPStegano
 
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 ```
 
 


### PR DESCRIPTION
In order to install deps properly (to be able to execute the script with python3), requirements need to be handled using `pip3` instead of `pip`.